### PR TITLE
build: use gcc for zoneinfo

### DIFF
--- a/share/zoneinfo/Makefile
+++ b/share/zoneinfo/Makefile
@@ -20,7 +20,7 @@ LOCALTIME=	US/Pacific
 
 CFLAGS= -O
 LINTFLAGS=	-phbaxc
-CC=		cc
+CC=		gcc
 CFLAGS+=	-g -Wall -Werror -idirafter $(TOPSRC)/include
 
 TZCSRCS=	zic.c scheck.c ialloc.c


### PR DESCRIPTION
Otherwise FreeBSD's cc (clang 16 for example) might
issue warnings for non-ANSI prototypes.