### PR TITLE
get adventure to link

### DIFF
--- a/games/adventure/hdr.h
+++ b/games/adventure/hdr.h
@@ -27,8 +27,8 @@
 #endif
 #include <stdlib.h>
 
-int datfd;                              /* message file descriptor      */
-int delhit;
+extern int datfd;                              /* message file descriptor      */
+extern int delhit;
 
 #define DATFILE "glorkz"                /* all the original msgs        */
 #define DATSIZE (46*1024)               /* size of encrypted data       */
@@ -38,7 +38,7 @@ int delhit;
 #define FLUSHLINE while (getchar()!='\n')
 #define FLUSHLF   while (next()!=LF)
 
-char *wd1, *wd2;                        /* the complete words           */
+extern char *wd1, *wd2;                        /* the complete words           */
 
 struct hashtab {                        /* hash table for vocabulary    */
         int val;                        /* word type &index (ktab)      */
@@ -60,7 +60,7 @@ struct travlist {                       /* direcs & conditions of travel*/
 /*
  * Game state.
  */
-struct {
+struct game_struct {
     short loc, newloc, oldloc, oldlc2, wzdark, gaveup, kq, k, k2;
     short verb, obj, spk;
     short blklin;
@@ -128,9 +128,9 @@ struct {
         clock1, clock2, closng, panic, closed, scorng;
 
     short limit;
-} game;
+};
 
-struct travlist *tkk;                   /* travel is closer to keys(...)*/
+extern struct game_struct game;
 
 extern const short setbit[16];            /* bit defn masks 1,2,4,...     */
 

--- a/games/adventure/main.c
+++ b/games/adventure/main.c
@@ -8,6 +8,8 @@
 #include <fcntl.h>
 
 int	datfd;
+char *wd1, *wd2;
+int delhit;
 
 int
 main(argc, argv)

--- a/games/adventure/save.c
+++ b/games/adventure/save.c
@@ -5,6 +5,7 @@
 #include "hdr.h"
 #include <unistd.h>
 #include <fcntl.h>
+struct game_struct game;
 
 void
 save(savfile, offset)                   /* save game state to file      */

--- a/games/adventure/subr.c
+++ b/games/adventure/subr.c
@@ -2,6 +2,7 @@
  * Re-coding of advent in C: subroutines from main
  */
 #include "hdr.h"
+struct travlist *tkk;                   /* travel is closer to keys(...)*/
 
 /* Statement functions */
 


### PR DESCRIPTION
I had difficulty building discobsd because of how a header file for the game `adventure` didn't use extern in the way modern gcc expects, so here's a commit that fixed it.

I'm having the same problem with another game, atc. From the output of `gmake`:

```
gmake[2]: Entering directory '/home/somebody/proj/discobsd/games/atc'
/usr/bin/arm-none-eabi-gcc -mcpu=cortex-m4 -mabi=aapcs -mlittle-endian -mthumb -mfloat-abi=soft -nostdinc -I/home/somebody/proj/discobsd/include  -N -nostartfiles -fno-dwarf2-cfi-asm -T/home/somebody/proj/discobsd/lib/elf32-arm.ld /home/somebody/proj/discobsd/lib/crt0.o -L/home/somebody/proj/discobsd/lib -o atc.elf extern.o grammar.o input.o lex.o list.o log.o main.o tunable.o graphics.o update.o -lm -lcurses -ltermcap -lc
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: /home/somebody/proj/discobsd/lib/libm.a(sqrt.o):(.bss+0x0): multiple definition of `errno'; /home/somebody/proj/discobsd/lib/libm.a(asin.o):(.bss+0x0): first defined here
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: /home/somebody/proj/discobsd/lib/libcurses.a(cr_put.o):(.bss+0x18): multiple definition of `_win'; /home/somebody/proj/discobsd/lib/libcurses.a(refresh.o):(.bss+0x4): first defined here
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: /home/somebody/proj/discobsd/lib/libtermcap.a(tgoto.o):(.bss+0x50): multiple definition of `BC'; /home/somebody/proj/discobsd/lib/libcurses.a(curses.o):(.bss+0x104): first defined here
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: /home/somebody/proj/discobsd/lib/libtermcap.a(tgoto.o):(.bss+0x4c): multiple definition of `UP'; /home/somebody/proj/discobsd/lib/libcurses.a(curses.o):(.bss+0x3c): first defined here
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: /home/somebody/proj/discobsd/lib/libtermcap.a(tputs.o):(.bss+0x2): multiple definition of `PC'; /home/somebody/proj/discobsd/lib/libcurses.a(curses.o):(.bss+0x10): first defined here
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: /home/somebody/proj/discobsd/lib/libtermcap.a(tputs.o):(.bss+0x0): multiple definition of `ospeed'; /home/somebody/proj/discobsd/lib/libcurses.a(cr_tty.o):(.data+0x0): first defined here
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: /home/somebody/proj/discobsd/lib/libc.a(exit.o):(.bss+0xc): multiple definition of `errno'; /home/somebody/proj/discobsd/lib/libm.a(asin.o):(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
gmake[2]: *** [Makefile:25: atc] Error 1
gmake[2]: Leaving directory '/home/somebody/proj/discobsd/games/atc'
```

I think what this means is that some of the libraries (libm, libcurses, libtermcap, libc) each one has the same symbol declared several times). But I am not sure (yet!) how to fix these up.