### PR TITLE
FreeBSD require gcc-arm-embedded on STM32 (instead of arm-none-eabi-gcc)

### DIFF
--- a/target.mk
+++ b/target.mk
@@ -15,7 +15,7 @@ GCCPREFIX!=if [ x"${MACHINE_ARCH}" = x"arm" ] ; then \
 		if [ x"${_HOST_OSNAME}" = x"OpenBSD" ] ; then \
 			echo "/usr/local/bin/arm-none-eabi" ; \
 		elif [ x"${_HOST_OSNAME}" = x"FreeBSD" ] ; then \
-			echo "/usr/local/bin/arm-none-eabi" ; \
+			echo "/usr/local/gcc-arm-embedded/bin/arm-none-eabi" ; \
 		elif [ x"${_HOST_OSNAME}" = x"Linux" ] ; then \
 			echo "/usr/bin/arm-none-eabi" ; \
 		else \


### PR DESCRIPTION
FreeBSD ports provide two ARM compilers:

- [devel/arm-none-eabi-gcc](https://www.freshports.org/devel/arm-none-eabi-gcc)
- [devel/gcc-arm-embedded](https://www.freshports.org/devel/gcc-arm-embedded)

The second one is for embedded devices like STM2 familly. His path is /usr/local/gcc-arm-embedded/bin