### PR TITLE
Fix xinstall segfault on Linux

### DIFF
--- a/tools/binstall/xinstall.c
+++ b/tools/binstall/xinstall.c
@@ -196,15 +196,31 @@ main(int argc, char *argv[])
 	}
 
 	if (dodest) {
-		char *dest = dirname(argv[argc - 1]);
-		if (dest == NULL)
+		char *destcopy = strdup(argv[argc - 1]);
+		char *dest, *destdir;
+		if (destcopy == NULL)
+			err(1, "strdup");
+		dest = dirname(destcopy);
+		if (dest == NULL) {
+			free(destcopy);
 			errx(1, "cannot determine dirname");
+		}
+		/*
+		 * dirname() may return a pointer to static storage or
+		 * modify destcopy in place. Make a copy of the result
+		 * since install_dir() modifies its argument.
+		 */
+		destdir = strdup(dest);
+		free(destcopy);
+		if (destdir == NULL)
+			err(1, "strdup");
 		/*
 		 * When -D is passed, do not chmod the directory with the mode set for
 		 * the target file. If more restrictive permissions are required then
 		 * '-d -m' ought to be used instead.
 		 */
-		install_dir(dest, 0755);
+		install_dir(destdir, 0755);
+		free(destdir);
 	}
 
 	no_target = stat(to_name = argv[argc - 1], &to_sb);


### PR DESCRIPTION
On my Linux Mint (Ubuntu based), binstall segfaulted. Claude and I propose this fix that works on my machine, not tested on other OS.

### Root Cause
The segmentation fault was caused by two related issues with dirname() in the -D option handler:

- dirname() modifies its argument: According to POSIX, dirname() may modify the string passed to it. The original code passed argv[argc - 1] directly, which corrupted the destination path for subsequent operations.

- dirname() can return a static string: When the input has no directory component (e.g., justfile), dirname() returns a pointer to static read-only memory (the string "."). The install_dir() function then tried to modify this read-only memory at [xinstall.c:618], causing the segmentation fault.

### The Fix
The fix ([lines 194-220]) now:

- Creates a copy of argv[argc - 1] with strdup() before calling dirname()
- Creates a second copy of the dirname() result (which handles both cases: when it returns a pointer into the copy, and when it returns a static string)
- Properly frees both allocations
- 
This ensures argv[argc - 1] remains unchanged for later use, and install_dir() receives a modifiable string buffer.

